### PR TITLE
Add FreeBSD support using the same API as on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 A very small Python library to list the DLLs loaded by the current process.
 This is equivalent to the [`dllist`](https://docs.julialang.org/en/v1/stdlib/Libdl/#Base.Libc.Libdl.dllist) function in Julia.
 
-*Note*: This library is intended to work on macOS, Linux, and Windows. Other platforms will return an empty list and raise a warning.
+*Note*: This library is tested on macOS, Linux, and Windows.
+
+Some platforms which provide the same API as Linux (e.g. FreeBSD) may also work.
+
+Any other platform will return an empty list and raise a warning.
 
 ## Installation
 

--- a/dllist/__init__.py
+++ b/dllist/__init__.py
@@ -7,7 +7,7 @@ from typing import List
 __version__ = "1.1.0"
 
 _system = platform.system()
-if _system.startswith("Linux"):
+if _system.startswith("Linux") or _system.startswith("FreeBSD"):
     from .linux import _platform_specific_dllist
 elif _system.startswith("Darwin"):
     from .macos import _platform_specific_dllist

--- a/dllist/__init__.py
+++ b/dllist/__init__.py
@@ -4,14 +4,19 @@ import platform
 import warnings
 from typing import List
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
-_system = platform.system()
-if _system.startswith("Linux") or _system.startswith("FreeBSD"):
-    from .linux import _platform_specific_dllist
-elif _system.startswith("Darwin"):
+_system = platform.system().lower()
+if (
+    _system.startswith("linux")
+    or _system.startswith("freebsd")
+    or _system.startswith("openbsd")
+    or _system.startswith("solaris")
+):
+    from .unix_like import _platform_specific_dllist
+elif _system.startswith("darwin"):
     from .macos import _platform_specific_dllist
-elif _system.startswith("Windows"):
+elif _system.startswith("windows"):
     from .windows import _platform_specific_dllist
 else:
 

--- a/dllist/__init__.py
+++ b/dllist/__init__.py
@@ -11,6 +11,7 @@ if (
     _system.startswith("linux")
     or _system.startswith("freebsd")
     or _system.startswith("openbsd")
+    or _system.startswith("sunos")
     or _system.startswith("solaris")
 ):
     from .unix_like import _platform_specific_dllist

--- a/dllist/unix_like.py
+++ b/dllist/unix_like.py
@@ -3,7 +3,11 @@ import warnings
 from ctypes.util import find_library
 from typing import List
 
+# this uses functions common to Linux and a few other Unix-like systems
 # https://man7.org/linux/man-pages/man3/dl_iterate_phdr.3.html
+# https://man.freebsd.org/cgi/man.cgi?query=dl_iterate_phdr
+# https://man.openbsd.org/dl_iterate_phdr
+# https://docs.oracle.com/cd/E88353_01/html/E37843/dl-iterate-phdr-3c.html
 
 
 class dl_phdr_info(ctypes.Structure):

--- a/test/test_linux.py
+++ b/test/test_linux.py
@@ -2,8 +2,9 @@ import platform
 
 import pytest
 
-if not platform.system().startswith("Linux"):
-    pytest.skip(reason="Linux only", allow_module_level=True)
+system = platform.system()
+if not (system.startswith("Linux") or system.startswith("FreeBSD")):
+    pytest.skip(reason="Linux and FreeBSD only", allow_module_level=True)
 
 
 from test import print_list

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8,6 +8,7 @@ system = platform.system()
 
 if (
     system.startswith("Linux")
+    or system.startswith("FreeBSD")
     or system.startswith("Darwin")
     or system.startswith("Windows")
 ):


### PR DESCRIPTION
It turns out FreeBSD uses the same API as Linux for this, so it just works.

At least it does on 13.3 and later. FreeBSD 13.2 and earlier need a small tweak (as [described on the bug tracker](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272992)), but since 13.2 is only supported until the end of June, I'm not sure if it's worth complicating the code. It works on 13.2 with this change to `linux.py`:

```python
RTLD_DEFAULT = -2
libc = ctypes.CDLL("", handle=RTLD_DEFAULT)
```

But supporting 13.3 and later doesn't need any changes. In that case, is it confusing to have `linux.py` support both Linux and FreeBSD? Should I add a new `freebsd.py` that just imports the Linux implementation?