### PR TITLE
Add FreeBSD support to CI test workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,7 @@ jobs:
           '"
           --health-start-period 45s
           --health-timeout 240s
+          --device /dev/kvm
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,3 +30,79 @@ jobs:
 
       - name: Test
         run: pytest -v -s
+
+  test-freebsd:
+    runs-on: ubuntu-latest
+
+    services:
+      freebsd:
+        image: ghcr.io/tunedal/freebsd-qemu-container-python:1.0
+        ports:
+          - 2222
+        options: >-
+          --health-cmd "bash -c '
+          grep -m1 SSH </dev/tcp/localhost/2222 || exit 1
+          '"
+          --health-start-period 45s
+          --health-timeout 240s
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve service container configuration
+        run: |
+          docker cp ${{ job.services.freebsd.id }}:/mnt/config/ config
+          ls -l config
+
+      - name: Configure SSH client
+        run: |
+          cat >>config/ssh <<"EOF"
+          Host freebsd
+            Hostname localhost
+            Port ${{ job.services.freebsd.ports[2222] }}
+            User root
+            IdentityFile config/client_key
+            UserKnownHostsFile config/known_hosts
+          EOF
+
+      - name: Copy application files to VM
+        run: |
+          ssh -F config/ssh freebsd mkdir -p /tmp/dllist
+          tar zcf - --exclude ./config --exclude-vcs . | \
+            ssh -F config/ssh freebsd \
+            tar zxvf - -C /tmp/dllist
+
+      - name: Install for Python 3.8
+        run: |
+          ssh -F config/ssh freebsd '
+            cd /tmp/dllist
+            python3.8 -m venv env38
+            source env38/bin/activate.csh
+            pip install ".[test]"
+            pip install -e "test/test_éxt"
+          '
+
+      - name: Install for Python 3.11
+        run: |
+          ssh -F config/ssh freebsd '
+            cd /tmp/dllist
+            python3.11 -m venv env311
+            source env311/bin/activate.csh
+            pip install ".[test]"
+            pip install -e "test/test_éxt"
+          '
+
+      - name: Test on Python 3.8
+        run: |
+          ssh -F config/ssh freebsd '
+            cd /tmp/dllist
+            env38/bin/pytest -v -s
+          '
+
+      - name: Test on Python 3.11
+        run: |
+          ssh -F config/ssh freebsd '
+            cd /tmp/dllist
+            env311/bin/pytest -v -s
+          '


### PR DESCRIPTION

As you mentioned in PR #5, it would be useful to run the tests on FreeBSD in the CI. I have put together a Docker image based on QEMU and the official FreeBSD VM image to solve this:
https://github.com/tunedal/freebsd-qemu-container

It runs the tests on Python 3.8 and 3.11 (instead of 3.12) because that's what's packaged in FreeBSD, but I could update the image to include 3.12 built from source.

Enabling [hardware virtualization support](https://github.com/actions/runner-images/issues/183) substantially speeds up the `pip install` step (from 2.5 minutes to 20 seconds or so), but initializing the VM still takes almost 2 minutes, so I'm not sure how meaningful the difference is. Simply remove `--device /dev/kvm` from the workflow YAML if you prefer not to trust the container with access to KVM and run it with software emulation instead.

There are other implementations of the same idea, for example:
* https://github.com/cross-platform-actions/action
* https://github.com/vmactions/freebsd-vm
* https://github.com/qemus/qemu-docker

The advantage of my implementation is that it's comparatively simple and easy to audit: It's just a container, with no special GitHub integration. It's all in a single repo with uncomplicated dependencies and not much code. It doesn't require any special setup, so you should be able to build your own image just by cloning the repo.

If the job is too slow, there might be ways to speed it up: Perhaps removing unneeded devices from the emulator, perhaps caching the VM image externally instead of in the container image, perhaps using QEMU's snapshotting to restore an already booted VM, etc. Caching the pip dependencies in all jobs would probably speed up the workflow as a whole.

You can see an example of a test run here:
https://github.com/tunedal/dllist/actions/runs/9100060051/job/25014027490
